### PR TITLE
Implement State Machine

### DIFF
--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -41,6 +41,7 @@ crate mod caching;
 crate mod event_handler;
 crate mod internal_bot_error;
 crate mod model;
+crate mod state_machine;
 crate mod terminal;
 crate mod twilight_http_client_extensions;
 crate mod twilight_id_extensions;

--- a/src/system/state_machine.rs
+++ b/src/system/state_machine.rs
@@ -1,0 +1,40 @@
+//!  Copyright 2020 - 2021 The HarTex Project Developers
+//!
+//!  Licensed under the Apache License, Version 2.0 (the "License");
+//!  you may not use this file except in compliance with the License.
+//!  You may obtain a copy of the License at
+//!
+//!      http://www.apache.org/licenses/LICENSE-2.0
+//!
+//!  Unless required by applicable law or agreed to in writing, software
+//!  distributed under the License is distributed on an "AS IS" BASIS,
+//!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//!  See the License for the specific language governing permissions and
+//!  limitations under the License.
+
+use std::{
+    fmt::Debug
+};
+
+crate trait StateEnum {}
+
+#[derive(Debug, Clone)]
+crate struct StateMachine<S: Debug + Clone + StateEnum> {
+    crate state: S
+}
+
+impl<S: Debug + Clone + StateEnum> StateMachine<S> {
+    crate fn new_with_state_enum(state: S) -> Self {
+        Self {
+            state
+        }
+    }
+
+    crate fn update_state(&mut self, new_state: S) {
+        self.state = new_state
+    }
+    
+    crate fn state(&self) -> S {
+        self.state.clone()
+    }
+}


### PR DESCRIPTION
- [x] Implement the main `StateMachine` structure;
- [x] Make use of the newly created `StateMachine` for the message create filtering (zalgo, invites, domains, etc).

#### Implementation History
- [d617e1e9c](https://github.com/HT-Studios/HarTex-rust-discord-bot/commit/d617e1e9c8198fbe3bdf73a3b9974afa7158c13a)
- [3c7529f9d](https://github.com/HT-Studios/HarTex-rust-discord-bot/commit/3c7529f9d2bc8e08d585217e4b26b03fea52159d)