### PR TITLE
Update README Branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HarTex, a Rust Discord Bot
+# HarTex, a Discord Bot
 
 [![HarTex Community](https://img.shields.io/discord/886101109331075103?color=%237289DA&label=HarTex%20Community&logo=discord&style=for-the-badge)](https://discord.gg/Xu8453VBAv)
 


### PR DESCRIPTION
As this repository is no longer going to be pure Rust, it does not seem appropriate to have "Rust" in the README title anymore.