### PR TITLE
Remove `<br/>` Usage and Utilize CSS Instead

### DIFF
--- a/web-fullstack/web/src/components/InterchangeableDocumentation/InterchangeableDocumentation.styles.css
+++ b/web-fullstack/web/src/components/InterchangeableDocumentation/InterchangeableDocumentation.styles.css
@@ -46,3 +46,7 @@
 h1 {
   @apply text-5xl font-bold;
 }
+
+h2 {
+  @apply text-3xl font-bold;
+}

--- a/web-fullstack/web/src/components/InterchangeableDocumentation/InterchangeableDocumentation.styles.css
+++ b/web-fullstack/web/src/components/InterchangeableDocumentation/InterchangeableDocumentation.styles.css
@@ -45,8 +45,15 @@
 
 h1 {
   @apply text-5xl font-bold;
+  @apply mb-[18px];
 }
 
 h2 {
   @apply text-3xl font-bold;
+  @apply mt-9 mb-5;
+}
+
+.admonition p {
+  @apply text-1xl;
+  @apply mt-[18px];
 }

--- a/web-fullstack/web/src/components/InterchangeableDocumentation/InterchangeableDocumentation.tsx
+++ b/web-fullstack/web/src/components/InterchangeableDocumentation/InterchangeableDocumentation.tsx
@@ -158,13 +158,6 @@ function remarkHarTexPlugin() {
 
         node.children = [wrapper]
       }
-      else if (name === "br") {
-        const breaker = h('br')
-        const breakerData = breaker.data || (breaker.data = {})
-        breakerData.hName = "br"
-
-        node.children.splice(0, 0, breaker)
-      }
     })
 
     visit(tree, nodePredicate2, (node) => {

--- a/web-fullstack/web/src/components/InterchangeableDocumentation/InterchangeableDocumentation.tsx
+++ b/web-fullstack/web/src/components/InterchangeableDocumentation/InterchangeableDocumentation.tsx
@@ -83,7 +83,7 @@ function rehypeHarTexPlugin() {
 
   return (tree) => {
     visit(tree, nodePredicate1, (node) => {
-      node.properties = { id: node.children[0].value.toLowerCase() }
+      node.properties = { id: node.children[0].value.toLowerCase().replace(" ", "-") }
     })
   }
 }

--- a/web-fullstack/web/src/components/InterchangeableDocumentation/InterchangeableDocumentation.tsx
+++ b/web-fullstack/web/src/components/InterchangeableDocumentation/InterchangeableDocumentation.tsx
@@ -95,8 +95,8 @@ function remarkHarTexPlugin() {
   }
 
   function nodePredicate2(node: any): boolean {
-    const { type, tagName } = node
-    return type === "heading" && ["h2", "h3", "h4", "h5", "h6"].includes(tagName)
+    const { type, depth } = node
+    return type === "heading" && depth >= 2
   }
 
   const admonitionTypes = {

--- a/web-fullstack/web/src/markdown/documentation/welcome.md
+++ b/web-fullstack/web/src/markdown/documentation/welcome.md
@@ -1,7 +1,5 @@
 # Welcome
 
-:::br
-
 :::warning
 
 The HarTex Documentation in its current state is highly
@@ -15,25 +13,15 @@ whether you're a HarTex user going through the documentation,
 or just someone intrigued wanting to take a deeper look, this
 Documentation's got you covered!
 
-:::br
-
 This Documentation is [publicly hosted at GitHub](https://github.com/TeamHarTex/HarTex).
 Corrections and improvements are more than appreciated! <3
 
-:::br
-
 ## Bug Reporting
-
-:::br
 
 If you believe you're experiencing a bug with the bot or want to report incorrect
 documentation, please open an issue at [our issue tracker](https://github.com/TeamHarTex/HarTex/issues).
 
-:::br
-
 ## Still Need Support?
-
-:::br
 
 You may join our [Discord server](https://discord.gg/Xu8453VBAv) for further support and
 dicussion.

--- a/web-fullstack/web/src/markdown/documentation/welcome.md
+++ b/web-fullstack/web/src/markdown/documentation/welcome.md
@@ -20,12 +20,16 @@ Documentation's got you covered!
 This Documentation is [publicly hosted at GitHub](https://github.com/TeamHarTex/HarTex).
 Corrections and improvements are more than appreciated! <3
 
+:::br
+
 ## Bug Reporting
 
 :::br
 
 If you believe you're experiencing a bug with the bot or want to report incorrect
 documentation, please open an issue at [our issue tracker](https://github.com/TeamHarTex/HarTex/issues).
+
+:::br
 
 ## Still Need Support?
 


### PR DESCRIPTION
This PR changes the way how documentation is laid out. `:::br` lines are no longer required in the raw markdown as CSS has taken over for the spacing.