### PR TITLE
Pull `twilight` From `next`

### DIFF
--- a/discord-frontend/Cargo.lock
+++ b/discord-frontend/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "arc-swap"
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1063,15 +1063,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "leaky-bucket-lite"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1411c737dd21a748044ab29af14b7f920b2dcc277284df6dd986492c98bf5229"
-dependencies = [
- "tokio",
-]
 
 [[package]]
 name = "libc"
@@ -1633,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "6df50b7a60a0ad48e1b42eb38373eac8ff785d619fb14db917b4e63d5439361f"
 dependencies = [
  "serde_derive",
 ]
@@ -1652,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "a714fd32ba1d66047ce7d53dabd809e9922d538f9047de13cc4cffca47b36205"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1887,9 +1878,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2135,12 +2126,12 @@ dependencies = [
 [[package]]
 name = "twilight-gateway"
 version = "0.13.3"
-source = "git+https://github.com/twilight-rs/twilight.git?branch=vilgotf/fix/gateway/resume#ae494853b89b579b4d2feb55f0d276e80f0af128"
+source = "git+https://github.com/twilight-rs/twilight.git?branch=next#f11112149bc5f34fe1f7da315460aa5be05c150e"
 dependencies = [
  "bitflags",
  "flate2",
  "futures-util",
- "leaky-bucket-lite",
+ "rand",
  "rustls",
  "rustls-native-certs",
  "serde",
@@ -2156,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "twilight-gateway-queue"
 version = "0.13.1"
-source = "git+https://github.com/twilight-rs/twilight.git?branch=vilgotf/fix/gateway/resume#ae494853b89b579b4d2feb55f0d276e80f0af128"
+source = "git+https://github.com/twilight-rs/twilight.git?branch=next#f11112149bc5f34fe1f7da315460aa5be05c150e"
 dependencies = [
  "tokio",
  "tracing",
@@ -2165,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "twilight-http"
 version = "0.13.2"
-source = "git+https://github.com/twilight-rs/twilight.git?branch=vilgotf/fix/gateway/resume#ae494853b89b579b4d2feb55f0d276e80f0af128"
+source = "git+https://github.com/twilight-rs/twilight.git?branch=next#f11112149bc5f34fe1f7da315460aa5be05c150e"
 dependencies = [
  "hyper",
  "percent-encoding",
@@ -2182,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "twilight-http-ratelimiting"
 version = "0.13.2"
-source = "git+https://github.com/twilight-rs/twilight.git?branch=vilgotf/fix/gateway/resume#ae494853b89b579b4d2feb55f0d276e80f0af128"
+source = "git+https://github.com/twilight-rs/twilight.git?branch=next#f11112149bc5f34fe1f7da315460aa5be05c150e"
 dependencies = [
  "futures-util",
  "http",
@@ -2193,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "twilight-model"
 version = "0.13.5"
-source = "git+https://github.com/twilight-rs/twilight.git?branch=vilgotf/fix/gateway/resume#ae494853b89b579b4d2feb55f0d276e80f0af128"
+source = "git+https://github.com/twilight-rs/twilight.git?branch=next#f11112149bc5f34fe1f7da315460aa5be05c150e"
 dependencies = [
  "bitflags",
  "serde",
@@ -2206,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "twilight-validate"
 version = "0.13.1"
-source = "git+https://github.com/twilight-rs/twilight.git?branch=vilgotf/fix/gateway/resume#ae494853b89b579b4d2feb55f0d276e80f0af128"
+source = "git+https://github.com/twilight-rs/twilight.git?branch=next#f11112149bc5f34fe1f7da315460aa5be05c150e"
 dependencies = [
  "twilight-model",
 ]

--- a/discord-frontend/hartex-discord-core/Cargo.toml
+++ b/discord-frontend/hartex-discord-core/Cargo.toml
@@ -15,8 +15,8 @@ dotenv = { version = "0.15.0", optional = true }
 log = { version = "0.4.17", optional = true }
 log4rs = { version = "1.2.0", default-features = false, optional = true }
 tokio = { version = "1.21.2", optional = true }
-twilight-gateway = { git = "https://github.com/twilight-rs/twilight.git", branch = "vilgotf/fix/gateway/resume", optional = true }
-twilight-model = { git = "https://github.com/twilight-rs/twilight.git", branch = "vilgotf/fix/gateway/resume", optional = true }
+twilight-gateway = { git = "https://github.com/twilight-rs/twilight.git", branch = "next", optional = true }
+twilight-model = { git = "https://github.com/twilight-rs/twilight.git", branch = "next", optional = true }
 
 [features]
 async-runtime = ["dep:tokio", "tokio?/macros", "tokio?/rt", "tokio?/rt-multi-thread"]


### PR DESCRIPTION
This PR repulls `twilight` from the `next` branch as most of the gateway PRs are merged and the issue of `INVALID_SESSION`s is solved.