### PR TITLE
Use Older Nightly For `discord-frontend` Test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-02-03
       - name: Install cargo-nextest
         uses: baptiste0928/cargo-install@v1
         with:


### PR DESCRIPTION
In light of https://github.com/rust-lang/rust/issues/107678 which causes nightly to break for the `discord-frontend` test, a nightly rollback will be in place to temporarily fix the CI until the abovementioned issue is fixed.