### PR TITLE
Buildsystem Rework XI

### DIFF
--- a/.github/workflows/buildsystem.yml
+++ b/.github/workflows/buildsystem.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
   steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: Install latest nightly Rust toolchain
       uses: dtolnay/rust-toolchain@v1
       with:

--- a/.github/workflows/buildsystem.yml
+++ b/.github/workflows/buildsystem.yml
@@ -1,0 +1,18 @@
+name: Buildsystem
+
+on: workflow_dispatch
+
+jobs:
+  BuildAndRelease:
+    name: Build and Release Buildsystem
+    runs-on: ubuntu-latest
+
+  steps:
+    - uses: actions/checkout@v3
+    - name: Install latest nightly Rust toolchain
+      uses: dtolnay/rust-toolchain@v1
+      with:
+        components: clippy
+        toolchain: nightly
+    - name: Build buildsystem
+      run: cd hartexbuild && cargo build --release

--- a/.github/workflows/buildsystem.yml
+++ b/.github/workflows/buildsystem.yml
@@ -7,12 +7,12 @@ jobs:
     name: Build and Release Buildsystem
     runs-on: ubuntu-latest
 
-  steps:
-    - uses: actions/checkout@v3
-    - name: Install latest nightly Rust toolchain
-      uses: dtolnay/rust-toolchain@v1
-      with:
-        components: clippy
-        toolchain: nightly
-    - name: Build buildsystem
-      run: cd hartexbuild && cargo build --release
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest nightly Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          components: clippy
+          toolchain: nightly
+      - name: Build buildsystem
+        run: cd hartexbuild && cargo build --release

--- a/.github/workflows/buildsystem.yml
+++ b/.github/workflows/buildsystem.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+    - uses: actions/checkout@v3
     - name: Install latest nightly Rust toolchain
       uses: dtolnay/rust-toolchain@v1
       with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -15,8 +15,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -38,8 +36,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -61,8 +57,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -84,8 +78,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -107,8 +99,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -130,8 +120,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -42,8 +40,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -70,8 +66,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -92,8 +86,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -116,8 +108,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:


### PR DESCRIPTION
This PR creates a new workflow to prepare for manually running the workflow to create a new release of the Rust-based buildsystem.