### PR TITLE
Bors: Add Missing Associate Try Build Invocation

### DIFF
--- a/bors/hartex-bors-commands/src/commands/try.rs
+++ b/bors/hartex-bors-commands/src/commands/try.rs
@@ -69,6 +69,10 @@ pub async fn try_command<C: RepositoryClient>(
         )
         .await?;
 
+    database
+        .associate_try_build(&pr_model, TRY_BRANCH_NAME.to_string(), merge_hash.clone())
+        .await?;
+
     repository
         .client
         .set_branch_to_revision(TRY_BRANCH_NAME, &merge_hash)

--- a/bors/hartex-bors-driver/src/event.rs
+++ b/bors/hartex-bors-driver/src/event.rs
@@ -123,7 +123,8 @@ pub async fn handle_event(
                 state,
                 &GithubRepositoryName::new_from_repository(event.repository.repository)?,
             ) {
-                crate::workflows::workflow_started(repository, database, payload.workflow_run).await?;
+                crate::workflows::workflow_started(repository, database, payload.workflow_run)
+                    .await?;
             }
         }
         BorsEventKind::WorkflowRun(payload)


### PR DESCRIPTION
This should fix the try build successful message not being sent.