### PR TITLE
Pin `nightly-2025-08-10` Temporarily

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly
-          components: clippy, llvm-tools, rustc-dev
+          toolchain: nightly-2025-08-10
+          components: clippy
       - name: Install Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly
-          components: llvm-tools, rustc-dev
+          toolchain: nightly-2025-08-10
       - name: Install Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -50,8 +49,7 @@ jobs:
       - name: Install latest nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly
-          components: llvm-tools, rustc-dev
+          toolchain: nightly-2025-08-10
       - name: Install Python 3.11
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Pins the Rust version to `nightly-2025-08-10` temporarily until https://github.com/rust-lang/rust/issues/145288 is fixed.